### PR TITLE
Fix: Add binary data support to ResponseBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ app.get("/users/:id", (_, res, params) => res.send({ userId: params?.id }));
 // Route to handle query parameters (?key=value)
 app.get("/search", (_, res, __, queries) => res.send({ query: queries }));
 
+// Route to send binary data (PDF, images, etc.)
+app.get("/pdf", async (_, res) => {
+  const pdf = await Deno.readFile("./example.pdf");
+  return res.setHeader("Content-Type", "application/pdf").send(pdf.buffer);
+});
+
 app.cors(); // Enable CORS
 
 Deno.serve({ port: 9090 }, (req) => app.handler(req));
@@ -66,4 +72,4 @@ deno test --allow-net
 
 MIT
 
-<small>This README.md document was created with the help of ChatGPT.</small>
+<small>This README.md document was created with the help of AI.</small>

--- a/deno.json
+++ b/deno.json
@@ -1,15 +1,16 @@
 {
-  "name": "@prybet/router",
-  "version": "0.1.3",
-  "license": "MIT",
-  "exports": "./src/router.ts",
-  "imports": {
-    "@std/route": "jsr:@std/http/unstable-route",
-    "@std/assert": "jsr:@std/assert@1"
-  },
-  "exclude": [
-    ".github/",
-    ".gitattributes",
-    "main_test.ts"
-  ]
+    "name": "@prybet/router",
+    "version": "0.1.4",
+    "license": "MIT",
+    "exports": "./src/router.ts",
+    "imports": {
+        "@std/route": "jsr:@std/http/unstable-route",
+        "@std/file-server": "jsr:@std/http/file-server",
+        "@std/assert": "jsr:@std/assert@1"
+    },
+    "exclude": [
+        ".github/",
+        ".gitattributes",
+        "main_test.ts"
+    ]
 }

--- a/main_test.ts
+++ b/main_test.ts
@@ -48,3 +48,63 @@ Deno.test("404 for unknown routes", async () => {
 
   assertEquals(response.status, 404);
 });
+
+Deno.test("GET route should send ArrayBuffer correctly", async () => {
+  const app = new Router();
+
+  app.get("/buffer", (_, res) => {
+    const data = new TextEncoder().encode("Hello Buffer");
+    return res
+      .setHeader("Content-Type", "application/octet-stream")
+      .send(data.buffer);
+  });
+
+  const request = new Request("http://localhost/buffer");
+  const response = await app.handler(request);
+
+  const buffer = await response.arrayBuffer();
+  const text = new TextDecoder().decode(buffer);
+
+  assertEquals(text, "Hello Buffer");
+  assertEquals(
+    response.headers.get("Content-Type"),
+    "application/octet-stream"
+  );
+  assertEquals(response.status, 200);
+});
+
+Deno.test("GET route should send Uint8Array correctly", async () => {
+  const app = new Router();
+
+  app.get("/uint8", (_, res) => {
+    const data = new Uint8Array([72, 101, 108, 108, 111]);
+    return res.setHeader("Content-Type", "application/octet-stream").send(data);
+  });
+
+  const request = new Request("http://localhost/uint8");
+  const response = await app.handler(request);
+
+  const buffer = await response.arrayBuffer();
+  const text = new TextDecoder().decode(buffer);
+
+  assertEquals(text, "Hello");
+  assertEquals(response.status, 200);
+});
+
+Deno.test("GET route should send Blob correctly", async () => {
+  const app = new Router();
+
+  app.get("/blob", (_, res) => {
+    const blob = new Blob(["Test Blob Content"], { type: "text/plain" });
+    return res.setHeader("Content-Type", "text/plain").send(blob);
+  });
+
+  const request = new Request("http://localhost/blob");
+  const response = await app.handler(request);
+
+  const text = await response.text();
+
+  assertEquals(text, "Test Blob Content");
+  assertEquals(response.headers.get("Content-Type"), "text/plain");
+  assertEquals(response.status, 200);
+});


### PR DESCRIPTION
- Add isBinary() helper to detect ArrayBuffer, TypedArrays, Blob, and ReadableStream
- Update send() method to handle binary data without JSON serialization
- Add binary response example to README (/pdf route)
- Update dependencies in deno.json