### PR TITLE
HotFix: Use bare specifiers for JSR compatibility

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -4,9 +4,9 @@
     "license": "MIT",
     "exports": "./src/router.ts",
     "imports": {
-        "@std/route": "jsr:@std/http/unstable-route",
-        "@std/file-server": "jsr:@std/http/file-server",
-        "@std/assert": "jsr:@std/assert@1"
+        "@std/http/unstable-route": "jsr:@std/http@^1.0.13/unstable-route",
+        "@std/http/file-server": "jsr:@std/http@^1.0.13/file-server",
+        "@std/assert": "jsr:@std/assert@^1"
     },
     "exclude": [
         ".github/",

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,5 +1,5 @@
-import { route, type Route } from "@std/route";
-import { serveDir, type ServeDirOptions } from "@std/file-server";
+import { route, type Route } from "@std/http/unstable-route";
+import { serveDir, type ServeDirOptions } from "@std/http/file-server";
 
 /**
  * Type definition for a route handler function.


### PR DESCRIPTION
- Replace inline jsr: imports with bare specifiers
- Add proper import mappings in deno.json
- Fix JSR publish constraints without functionality changes