### PR TITLE
Fix: Handle string responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ app.get("/pdf", async (_, res) => {
   return res.setHeader("Content-Type", "application/pdf").send(pdf.buffer);
 });
 
+// Route to send SVG
+app.get("/svg", (_, res) => {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <circle cx="50" cy="50" r="40" fill="red" />
+</svg>`;
+  return res.setHeader("Content-Type", "image/svg+xml").send(svg);
+});
+
 app.cors(); // Enable CORS
 
 Deno.serve({ port: 9090 }, (req) => app.handler(req));

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
     "name": "@prybet/router",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "license": "MIT",
     "exports": "./src/router.ts",
     "imports": {

--- a/deno.lock
+++ b/deno.lock
@@ -1,44 +1,49 @@
 {
-  "version": "4",
+  "version": "5",
   "specifiers": {
     "jsr:@std/assert@1": "1.0.11",
-    "jsr:@std/cli@^1.0.12": "1.0.13",
-    "jsr:@std/encoding@^1.0.7": "1.0.7",
-    "jsr:@std/fmt@^1.0.5": "1.0.5",
-    "jsr:@std/html@^1.0.3": "1.0.3",
-    "jsr:@std/http@*": "1.0.13",
-    "jsr:@std/http@1.0.13": "1.0.13",
+    "jsr:@std/cli@^1.0.21": "1.0.22",
+    "jsr:@std/encoding@^1.0.10": "1.0.10",
+    "jsr:@std/fmt@^1.0.8": "1.0.8",
+    "jsr:@std/fs@^1.0.19": "1.0.19",
+    "jsr:@std/html@^1.0.4": "1.0.4",
+    "jsr:@std/http@^1.0.13": "1.0.20",
+    "jsr:@std/internal@^1.0.10": "1.0.10",
     "jsr:@std/internal@^1.0.5": "1.0.5",
     "jsr:@std/media-types@^1.1.0": "1.1.0",
-    "jsr:@std/net@^1.0.4": "1.0.4",
-    "jsr:@std/path@^1.0.8": "1.0.8",
-    "jsr:@std/streams@^1.0.9": "1.0.9"
+    "jsr:@std/net@^1.0.4": "1.0.6",
+    "jsr:@std/path@^1.1.1": "1.1.2",
+    "jsr:@std/streams@^1.0.10": "1.0.12"
   },
   "jsr": {
     "@std/assert@1.0.11": {
       "integrity": "2461ef3c368fe88bc60e186e7744a93112f16fd110022e113a0849e94d1c83c1",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.5"
       ]
     },
-    "@std/cli@1.0.13": {
-      "integrity": "5db2d95ab2dca3bca9fb6ad3c19908c314e93d6391c8b026725e4892d4615a69"
+    "@std/cli@1.0.22": {
+      "integrity": "50d1e4f87887cb8a8afa29b88505ab5081188f5cad3985460c3b471fa49ff21a"
     },
-    "@std/encoding@1.0.7": {
-      "integrity": "f631247c1698fef289f2de9e2a33d571e46133b38d042905e3eac3715030a82d"
+    "@std/encoding@1.0.10": {
+      "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
     },
-    "@std/fmt@1.0.5": {
-      "integrity": "0cfab43364bc36650d83c425cd6d99910fc20c4576631149f0f987eddede1a4d"
+    "@std/fmt@1.0.8": {
+      "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
     },
-    "@std/html@1.0.3": {
-      "integrity": "7a0ac35e050431fb49d44e61c8b8aac1ebd55937e0dc9ec6409aa4bab39a7988"
+    "@std/fs@1.0.19": {
+      "integrity": "051968c2b1eae4d2ea9f79a08a3845740ef6af10356aff43d3e2ef11ed09fb06"
     },
-    "@std/http@1.0.13": {
-      "integrity": "d29618b982f7ae44380111f7e5b43da59b15db64101198bb5f77100d44eb1e1e",
+    "@std/html@1.0.4": {
+      "integrity": "eff3497c08164e6ada49b7f81a28b5108087033823153d065e3f89467dd3d50e"
+    },
+    "@std/http@1.0.20": {
+      "integrity": "b5cc33fc001bccce65ed4c51815668c9891c69ccd908295997e983d8f56070a1",
       "dependencies": [
         "jsr:@std/cli",
         "jsr:@std/encoding",
         "jsr:@std/fmt",
+        "jsr:@std/fs",
         "jsr:@std/html",
         "jsr:@std/media-types",
         "jsr:@std/net",
@@ -49,23 +54,29 @@
     "@std/internal@1.0.5": {
       "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
     },
+    "@std/internal@1.0.10": {
+      "integrity": "e3be62ce42cab0e177c27698e5d9800122f67b766a0bea6ca4867886cbde8cf7"
+    },
     "@std/media-types@1.1.0": {
       "integrity": "c9d093f0c05c3512932b330e3cc1fe1d627b301db33a4c2c2185c02471d6eaa4"
     },
-    "@std/net@1.0.4": {
-      "integrity": "2f403b455ebbccf83d8a027d29c5a9e3a2452fea39bb2da7f2c04af09c8bc852"
+    "@std/net@1.0.6": {
+      "integrity": "110735f93e95bb9feb95790a8b1d1bf69ec0dc74f3f97a00a76ea5efea25500c"
     },
-    "@std/path@1.0.8": {
-      "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
+    "@std/path@1.1.2": {
+      "integrity": "c0b13b97dfe06546d5e16bf3966b1cadf92e1cc83e56ba5476ad8b498d9e3038",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.10"
+      ]
     },
-    "@std/streams@1.0.9": {
-      "integrity": "a9d26b1988cdd7aa7b1f4b51e1c36c1557f3f252880fa6cc5b9f37078b1a5035"
+    "@std/streams@1.0.12": {
+      "integrity": "ae925fa1dc459b1abf5cbaa28cc5c7b0485853af3b2a384b0dc22d86e59dfbf4"
     }
   },
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@1",
-      "jsr:@std/http@*"
+      "jsr:@std/http@^1.0.13"
     ]
   }
 }

--- a/main_test.ts
+++ b/main_test.ts
@@ -108,3 +108,27 @@ Deno.test("GET route should send Blob correctly", async () => {
   assertEquals(response.headers.get("Content-Type"), "text/plain");
   assertEquals(response.status, 200);
 });
+
+Deno.test(
+  "GET route should send string/SVG without JSON.stringify",
+  async () => {
+    const app = new Router();
+
+    app.get("/svg", (_, res) => {
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="40"/></svg>`;
+      return res.setHeader("Content-Type", "image/svg+xml").send(svg);
+    });
+
+    const request = new Request("http://localhost/svg");
+    const response = await app.handler(request);
+
+    const text = await response.text();
+
+    assertEquals(
+      text,
+      `<svg xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="40"/></svg>`
+    );
+    assertEquals(response.headers.get("Content-Type"), "image/svg+xml");
+    assertEquals(response.status, 200);
+  }
+);

--- a/src/router.ts
+++ b/src/router.ts
@@ -216,7 +216,12 @@ class ResponseBuilder {
         headers: this.headers,
       });
 
-    const body = isBinary(data) ? data : JSON.stringify(data);
+    const body = isBinary(data)
+      ? data
+      : typeof data === "object"
+      ? JSON.stringify(data)
+      : String(data);
+
     return new Response(body as BodyInit, {
       status: this.code,
       headers: this.headers,


### PR DESCRIPTION
- Add string type check in send() to pass text directly
- Prevent double-stringification of SVG, HTML, and plain text responses
- Add SVG response example to README
- Add test for string/SVG response handling
- Bump version to 0.1.5